### PR TITLE
Add standalone Spotify Clone app with Vite dev server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ lib/
 es/
 coverage/
 .vscode/
+dist/
+*.local
 
 # yarn
 .yarn/

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1,0 +1,55 @@
+# Development Setup
+
+This project now supports both a standalone Spotify Clone app and Storybook for component development.
+
+## Running the Spotify Clone App
+
+To run the Spotify clone as a standalone application:
+
+```bash
+npm run dev
+# or
+yarn dev
+```
+
+This will start the Vite dev server on **http://localhost:3000/**
+
+## Running Storybook
+
+To run Storybook for component development and documentation:
+
+```bash
+npm run storybook
+# or
+yarn storybook
+```
+
+This will start Storybook on **http://localhost:9000/**
+
+## Project Structure
+
+- `app/` - Vite app entry point
+  - `main.tsx` - App entry file
+  - `index.css` - Global styles
+- `stories/` - Storybook stories and components
+  - `spotify-clone.tsx` - Spotify clone component
+  - `spotify-clone.scss` - Spotify clone styles
+  - `spotify-clone.stories.js` - Storybook story
+- `src/` - Audio player library components
+- `index.html` - HTML entry for Vite app
+- `vite.config.ts` - Vite configuration
+
+## Available Scripts
+
+- `npm run dev` - Start Vite dev server (Spotify clone app)
+- `npm run storybook` - Start Storybook dev server
+- `npm run build` - Build the library
+- `npm run build:storybook` - Build Storybook for deployment
+- `npm test` - Run tests
+- `npm run lint` - Lint code
+
+## Notes
+
+- The Spotify clone uses the H5AudioPlayer library from the `src/` directory
+- The app runs on port 3000 by default (configurable in `vite.config.ts`)
+- Storybook runs on port 9000 (configurable in package.json)

--- a/app/index.css
+++ b/app/index.css
@@ -1,0 +1,19 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Arimo', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+  width: 100%;
+  height: 100vh;
+}

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import SpotifyClone from '../stories/spotify-clone.tsx'
+import '../stories/spotify-clone.scss'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <SpotifyClone />
+  </React.StrictMode>,
+)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spotify Clone</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/app/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:d.ts": "tsc",
     "build:css": "sass --no-source-map src/styles.scss lib/styles.css",
     "build:less": "sass2less src/styles.scss lib/styles.less",
+    "start": "npm run storybook",
     "lint": "eslint src --fix --ext .ts,.tsx",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "@vitejs/plugin-react": "^5.0.4",
     "babel-jest": "^29.7.0",
     "babel-loader": "^10.0.0",
     "cross-env": "^10",
@@ -103,6 +104,7 @@
     "storybook": "^9.0.0",
     "style-loader": "^4.0.0",
     "typescript": "^5.4.0",
+    "vite": "^7.1.9",
     "webpack": "^5",
     "webpack-cli": "^4"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./es/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
+    "dev": "vite",
     "build": "run-p build:cjs build:d.ts build:es build:umd build:css build:less",
     "build:cjs": "cross-env NODE_ENV=cjs babel src --out-dir lib --extensions .tsx,.ts",
     "build:es": "cross-env NODE_ENV=es babel src --out-dir es --extensions .tsx,.ts",
@@ -13,7 +14,8 @@
     "build:d.ts": "tsc",
     "build:css": "sass --no-source-map src/styles.scss lib/styles.css",
     "build:less": "sass2less src/styles.scss lib/styles.less",
-    "start": "npm run storybook",
+    "preview": "vite preview",
+    "start": "npm run dev",
     "lint": "eslint src --fix --ext .ts,.tsx",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -77,7 +79,6 @@
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "@vitejs/plugin-react": "^5.0.4",
     "babel-jest": "^29.7.0",
     "babel-loader": "^10.0.0",
     "cross-env": "^10",
@@ -104,7 +105,6 @@
     "storybook": "^9.0.0",
     "style-loader": "^4.0.0",
     "typescript": "^5.4.0",
-    "vite": "^7.1.9",
     "webpack": "^5",
     "webpack-cli": "^4"
   },

--- a/stories/spotify-clone.scss
+++ b/stories/spotify-clone.scss
@@ -450,6 +450,8 @@
     width: 70px;
     height: 70px;
     background: #1E2939;
+    background-size: cover;
+    background-position: center;
     flex-shrink: 0;
   }
   
@@ -528,6 +530,8 @@
       width: 100%;
       aspect-ratio: 1;
       background: #1E2939;
+      background-size: cover;
+      background-position: center;
       border-radius: 8.75px;
     }
     
@@ -625,6 +629,8 @@
     width: 49px;
     height: 49px;
     background: #1E2939;
+    background-size: cover;
+    background-position: center;
     border-radius: 3.5px;
     flex-shrink: 0;
   }

--- a/stories/spotify-clone.scss
+++ b/stories/spotify-clone.scss
@@ -760,21 +760,32 @@
       background: #6A7282;
       border-radius: 50px;
       cursor: pointer;
-      
+
+      .progress-input {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 20px;
+        opacity: 0;
+        cursor: pointer;
+        z-index: 2;
+      }
+
       .progress-filled {
         position: absolute;
         top: 0;
         left: 0;
         height: 100%;
-        width: 0.25%;
         background: #FFF;
         border-radius: 50px;
+        pointer-events: none;
       }
-      
+
       .progress-handle {
         position: absolute;
         top: 50%;
-        left: 0.25%;
         transform: translate(-50%, -50%);
         width: 11px;
         height: 11px;
@@ -783,8 +794,9 @@
         box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
         opacity: 0;
         transition: opacity 0.2s;
+        pointer-events: none;
       }
-      
+
       &:hover .progress-handle {
         opacity: 1;
       }
@@ -843,21 +855,32 @@
       background: #4A5565;
       border-radius: 50px;
       cursor: pointer;
-      
+
+      .volume-input {
+        position: absolute;
+        top: 50%;
+        left: 0;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 20px;
+        opacity: 0;
+        cursor: pointer;
+        z-index: 2;
+      }
+
       .volume-filled {
         position: absolute;
         top: 0;
         left: 0;
         height: 100%;
-        width: 80%;
         background: #FFF;
         border-radius: 50px;
+        pointer-events: none;
       }
-      
+
       .volume-handle {
         position: absolute;
         top: 50%;
-        left: 80%;
         transform: translate(-50%, -50%);
         width: 11px;
         height: 11px;
@@ -866,8 +889,9 @@
         box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
         opacity: 0;
         transition: opacity 0.2s;
+        pointer-events: none;
       }
-      
+
       &:hover .volume-handle {
         opacity: 1;
       }

--- a/stories/spotify-clone.scss
+++ b/stories/spotify-clone.scss
@@ -1,0 +1,908 @@
+@import url('https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&display=swap');
+
+.spotify-web-player {
+  font-family: 'Arimo', -apple-system, Roboto, Helvetica, sans-serif;
+  display: flex;
+  height: 100vh;
+  background: #000;
+  color: #fff;
+  overflow: hidden;
+}
+
+// Sidebar Styles
+.sidebar {
+  width: 224px;
+  background: #000;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  border-right: 1px solid #1E2939;
+}
+
+.sidebar-header {
+  padding: 21px;
+  padding-bottom: 0;
+}
+
+.spotify-logo {
+  display: flex;
+  align-items: center;
+  gap: 10.5px;
+  margin-bottom: 28px;
+  
+  svg {
+    width: 28px;
+    height: 28px;
+  }
+  
+  .spotify-text {
+    color: #FFF;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 24.5px;
+  }
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  
+  .nav-button {
+    display: flex;
+    align-items: center;
+    gap: 17.5px;
+    padding: 5.95px 10.5px 7.55px;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    color: #D1D5DC;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 17.5px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+    
+    &.active {
+      background: #1E2939;
+      color: #FFF;
+      
+      svg path {
+        stroke: #FFF;
+      }
+    }
+    
+    svg {
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+    }
+  }
+}
+
+.sidebar-divider {
+  height: 1px;
+  background: #1E2939;
+  margin-top: 21px;
+}
+
+.sidebar-library {
+  padding: 21px 0 21px 21px;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: #4A5565;
+    border-radius: 4px;
+  }
+}
+
+.library-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 21px;
+  margin-bottom: 14px;
+  
+  .library-button {
+    display: flex;
+    align-items: center;
+    gap: 17.5px;
+    padding: 5.95px 8.567px 7.55px 10.5px;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    color: #D1D5DC;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 17.5px;
+    cursor: pointer;
+    
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+  
+  .add-button {
+    display: flex;
+    width: 31.5px;
+    height: 28px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+}
+
+.sidebar-playlists {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-right: 21px;
+  
+  .playlist-item {
+    display: flex;
+    align-items: center;
+    gap: 10.5px;
+    padding: 0 10.5px;
+    height: 60px;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+    
+    .playlist-icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 3.5px;
+      background: #364153;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-shrink: 0;
+      
+      &.heart-icon {
+        background: linear-gradient(135deg, #9810FA 0%, #155DFC 100%);
+      }
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+    
+    .playlist-info {
+      flex: 1;
+      text-align: left;
+      overflow: hidden;
+      
+      .playlist-name {
+        color: #99A1AF;
+        font-size: 12px;
+        font-weight: 400;
+        line-height: 17.5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      
+      .playlist-count {
+        color: #6A7282;
+        font-size: 11px;
+        font-weight: 400;
+        line-height: 14px;
+      }
+    }
+  }
+}
+
+// Main Content Styles
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #101828 0%, #000 100%);
+  overflow: hidden;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 14px;
+  height: 56px;
+  background: #000;
+  flex-shrink: 0;
+  
+  .nav-controls {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    
+    .nav-arrow {
+      display: flex;
+      width: 28px;
+      height: 28px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 50%;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      
+      &.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      
+      &:not(.disabled):hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+    }
+    
+    .page-title {
+      color: #FFF;
+      font-size: 21px;
+      font-weight: 700;
+      line-height: 28px;
+      margin: 0;
+    }
+  }
+  
+  .user-controls {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    
+    .install-button {
+      display: flex;
+      align-items: center;
+      gap: 12.25px;
+      padding: 4.2px 9px 5.8px 8.75px;
+      border-radius: 6.75px;
+      background: transparent;
+      border: none;
+      color: #FFF;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 17.5px;
+      cursor: pointer;
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+      
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+    }
+    
+    .notification-button,
+    .user-button {
+      display: flex;
+      width: 28px;
+      height: 28px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 50%;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+      
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+    }
+    
+    .user-button {
+      background: #4A5565;
+      
+      &:hover {
+        background: #5A6575;
+      }
+    }
+  }
+}
+
+.page-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 21px;
+  
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: #4A5565;
+    border-radius: 6px;
+  }
+}
+
+.section {
+  margin-bottom: 28px;
+  
+  .section-title {
+    color: #FFF;
+    font-size: 21px;
+    font-weight: 400;
+    line-height: 28px;
+    margin: 0 0 14px;
+  }
+  
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 14px;
+    
+    .section-title {
+      margin: 0;
+      font-size: 18px;
+      line-height: 24.5px;
+    }
+    
+    .show-all-button {
+      padding: 7px 14px;
+      border-radius: 6.75px;
+      background: transparent;
+      border: none;
+      color: #99A1AF;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 17.5px;
+      cursor: pointer;
+      
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+    }
+  }
+}
+
+.quick-play-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  
+  @media (max-width: 1200px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.quick-play-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: #1E2939;
+  border-radius: 8.75px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  
+  &:hover {
+    background: #2A3949;
+    
+    .play-button-green {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+  
+  .quick-play-image {
+    width: 70px;
+    height: 70px;
+    background: #1E2939;
+    flex-shrink: 0;
+  }
+  
+  .quick-play-title {
+    flex: 1;
+    color: #FFF;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 23.633px;
+    text-align: left;
+    margin: 0;
+    padding-right: 50px;
+  }
+  
+  .play-button-green {
+    position: absolute;
+    right: 14px;
+    width: 33.25px;
+    height: 33.25px;
+    border-radius: 50%;
+    background: #00C950;
+    border: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    transform: translateY(8px);
+    opacity: 0;
+    transition: all 0.3s ease;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+    
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+    
+    &:hover {
+      background: #1ED760;
+      transform: scale(1.05) translateY(0);
+    }
+  }
+}
+
+.playlists-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 14px;
+  
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
+}
+
+.playlist-card {
+  background: #101828;
+  border-radius: 8.75px;
+  padding: 14px;
+  padding-bottom: 0;
+  transition: background-color 0.2s;
+  cursor: pointer;
+  
+  &:hover {
+    background: #1A2230;
+    
+    .play-button-overlay {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+  
+  .playlist-card-image-wrapper {
+    position: relative;
+    margin-bottom: 14px;
+    
+    .playlist-card-image {
+      width: 100%;
+      aspect-ratio: 1;
+      background: #1E2939;
+      border-radius: 8.75px;
+    }
+    
+    .play-button-overlay {
+      position: absolute;
+      bottom: 8px;
+      right: 8px;
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      background: #00C950;
+      border: none;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      cursor: pointer;
+      transform: translateY(8px);
+      opacity: 0;
+      transition: all 0.3s ease;
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+      
+      &:hover {
+        background: #1ED760;
+        transform: scale(1.05) translateY(0);
+      }
+    }
+  }
+  
+  .playlist-card-info {
+    padding-bottom: 14px;
+    
+    .playlist-card-title {
+      color: #FFF;
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 21px;
+      margin: 0 0 3.5px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    
+    .playlist-card-description {
+      color: #99A1AF;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 17.5px;
+      margin: 0;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+}
+
+// Music Player Styles
+.music-player-wrapper {
+  border-top: 0.917px solid #1E2939;
+  background: #101828;
+  flex-shrink: 0;
+}
+
+.music-player {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 14px;
+  height: 84.917px;
+  
+  @media (max-width: 992px) {
+    flex-direction: column;
+    height: auto;
+    padding: 14px;
+    gap: 14px;
+  }
+}
+
+.player-track-info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 280px;
+  
+  @media (max-width: 992px) {
+    width: 100%;
+  }
+  
+  .track-image {
+    width: 49px;
+    height: 49px;
+    background: #1E2939;
+    border-radius: 3.5px;
+    flex-shrink: 0;
+  }
+  
+  .track-details {
+    flex: 1;
+    overflow: hidden;
+    
+    .track-name {
+      color: #FFF;
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 21px;
+      margin: 0 0 2px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    
+    .track-artist {
+      color: #99A1AF;
+      font-size: 12px;
+      font-weight: 400;
+      line-height: 17.5px;
+      margin: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+  
+  .like-button,
+  .pip-button {
+    display: flex;
+    width: 31.5px;
+    height: 28px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+}
+
+.player-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+  flex: 1;
+  max-width: 600px;
+  
+  @media (max-width: 992px) {
+    width: 100%;
+    max-width: none;
+  }
+  
+  .control-buttons {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    
+    .control-button {
+      display: flex;
+      width: 31.5px;
+      height: 28px;
+      justify-content: center;
+      align-items: center;
+      border-radius: 6.75px;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      
+      svg {
+        width: 14px;
+        height: 14px;
+      }
+      
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      
+      &.play-pause {
+        width: 35px;
+        height: 35px;
+        background: #FFF;
+        border-radius: 50%;
+        
+        &:hover {
+          background: #FFF;
+          transform: scale(1.05);
+        }
+      }
+    }
+  }
+  
+  .progress-bar-container {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: 100%;
+    
+    .time-display {
+      color: #99A1AF;
+      font-size: 11px;
+      font-weight: 400;
+      line-height: 14px;
+      width: 35px;
+      text-align: center;
+    }
+    
+    .progress-bar {
+      position: relative;
+      flex: 1;
+      height: 4px;
+      background: #6A7282;
+      border-radius: 50px;
+      cursor: pointer;
+      
+      .progress-filled {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 0.25%;
+        background: #FFF;
+        border-radius: 50px;
+      }
+      
+      .progress-handle {
+        position: absolute;
+        top: 50%;
+        left: 0.25%;
+        transform: translate(-50%, -50%);
+        width: 11px;
+        height: 11px;
+        background: #FFF;
+        border-radius: 50%;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+      
+      &:hover .progress-handle {
+        opacity: 1;
+      }
+    }
+  }
+}
+
+.player-volume {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 280px;
+  justify-content: flex-end;
+  
+  @media (max-width: 992px) {
+    width: 100%;
+    justify-content: space-between;
+  }
+  
+  .volume-button,
+  .queue-button,
+  .fullscreen-button {
+    display: flex;
+    width: 31.5px;
+    height: 28px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 6.75px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+  
+  .volume-bar-wrapper {
+    width: 84px;
+    
+    @media (max-width: 992px) {
+      flex: 1;
+      max-width: 200px;
+    }
+    
+    .volume-bar {
+      position: relative;
+      width: 100%;
+      height: 4px;
+      background: #4A5565;
+      border-radius: 50px;
+      cursor: pointer;
+      
+      .volume-filled {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 80%;
+        background: #FFF;
+        border-radius: 50px;
+      }
+      
+      .volume-handle {
+        position: absolute;
+        top: 50%;
+        left: 80%;
+        transform: translate(-50%, -50%);
+        width: 11px;
+        height: 11px;
+        background: #FFF;
+        border-radius: 50%;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+      
+      &:hover .volume-handle {
+        opacity: 1;
+      }
+    }
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 768px) {
+  .sidebar {
+    width: 180px;
+  }
+  
+  .quick-play-section {
+    .section-title {
+      font-size: 18px;
+    }
+  }
+  
+  .playlists-section {
+    .section-title {
+      font-size: 16px;
+    }
+  }
+}
+
+@media (max-width: 576px) {
+  .sidebar {
+    position: fixed;
+    left: -224px;
+    top: 0;
+    bottom: 0;
+    z-index: 100;
+    transition: left 0.3s ease;
+    
+    &.open {
+      left: 0;
+    }
+  }
+  
+  .main-content {
+    width: 100%;
+  }
+}

--- a/stories/spotify-clone.stories.js
+++ b/stories/spotify-clone.stories.js
@@ -1,0 +1,15 @@
+import React from "react";
+import SpotifyClone from "./spotify-clone.tsx";
+
+export default {
+  title: "Spotify Clone",
+  component: SpotifyClone,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const Default = {
+  render: () => <SpotifyClone />,
+  name: "Spotify Web Player",
+};

--- a/stories/spotify-clone.tsx
+++ b/stories/spotify-clone.tsx
@@ -1,0 +1,479 @@
+import React, { Component } from 'react'
+import AudioPlayer from '../src/index'
+import './spotify-clone.scss'
+
+interface Track {
+  id: string
+  name: string
+  artist: string
+  duration: string
+  src: string
+  image?: string
+}
+
+interface Playlist {
+  id: string
+  name: string
+  description: string
+  tracks: Track[]
+  image?: string
+}
+
+interface SpotifyCloneState {
+  currentTrackIndex: number
+  currentPlaylist: Playlist
+  isPlaying: boolean
+  volume: number
+}
+
+const sampleTracks: Track[] = [
+  {
+    id: '1',
+    name: 'Blinding Lights',
+    artist: 'The Weeknd',
+    duration: '3:20',
+    src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+  },
+  {
+    id: '2',
+    name: 'Save Your Tears',
+    artist: 'The Weeknd',
+    duration: '3:35',
+    src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+  },
+  {
+    id: '3',
+    name: 'Levitating',
+    artist: 'Dua Lipa',
+    duration: '3:23',
+    src: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3',
+  },
+]
+
+const playlists: Playlist[] = [
+  {
+    id: 'top-hits',
+    name: "Today's Top Hits",
+    description: 'The most played songs on Spotify right now',
+    tracks: sampleTracks,
+  },
+  {
+    id: 'rapcaviar',
+    name: 'RapCaviar',
+    description: 'New music and big tracks from hip hop',
+    tracks: sampleTracks,
+  },
+  {
+    id: 'chill-hits',
+    name: 'Chill Hits',
+    description: 'Chill tracks for the perfect vibe',
+    tracks: sampleTracks,
+  },
+  {
+    id: 'pop-rising',
+    name: 'Pop Rising',
+    description: 'The biggest songs in pop are right here',
+    tracks: sampleTracks,
+  },
+  {
+    id: 'rock-classics',
+    name: 'Rock Classics',
+    description: 'Rock legends & epic guitar solos',
+    tracks: sampleTracks,
+  },
+  {
+    id: 'indie-mix',
+    name: 'Indie Mix',
+    description: 'The best indie tracks, updated weekly',
+    tracks: sampleTracks,
+  },
+]
+
+const quickPlayPlaylists = [
+  { name: "Today's Top Hits" },
+  { name: 'RapCaviar' },
+  { name: 'Chill Hits' },
+  { name: 'Pop Rising' },
+  { name: 'Rock Classics' },
+  { name: 'Indie Mix' },
+]
+
+const sidebarPlaylists = [
+  { name: 'Liked Songs', count: 234, icon: 'heart' },
+  { name: 'My Playlist #1', count: 45 },
+  { name: 'Chill Vibes', count: 67 },
+  { name: 'Workout Mix', count: 32 },
+  { name: 'Road Trip', count: 89 },
+  { name: 'Focus Music', count: 23 },
+  { name: 'Party Hits', count: 156 },
+  { name: 'Acoustic Sessions', count: 41 },
+]
+
+class SpotifyClone extends Component<{}, SpotifyCloneState> {
+  audioRef = React.createRef<HTMLAudioElement>()
+
+  state: SpotifyCloneState = {
+    currentTrackIndex: 0,
+    currentPlaylist: playlists[0],
+    isPlaying: false,
+    volume: 0.8,
+  }
+
+  handleClickPrevious = (): void => {
+    this.setState((prevState) => ({
+      currentTrackIndex:
+        prevState.currentTrackIndex === 0
+          ? prevState.currentPlaylist.tracks.length - 1
+          : prevState.currentTrackIndex - 1,
+    }))
+  }
+
+  handleClickNext = (): void => {
+    this.setState((prevState) => ({
+      currentTrackIndex:
+        prevState.currentTrackIndex < prevState.currentPlaylist.tracks.length - 1
+          ? prevState.currentTrackIndex + 1
+          : 0,
+    }))
+  }
+
+  handlePlayPlaylist = (playlistIndex: number): void => {
+    this.setState({
+      currentPlaylist: playlists[playlistIndex],
+      currentTrackIndex: 0,
+    })
+  }
+
+  render(): React.ReactNode {
+    const { currentTrackIndex, currentPlaylist } = this.state
+    const currentTrack = currentPlaylist.tracks[currentTrackIndex]
+
+    return (
+      <div className="spotify-web-player">
+        {/* Sidebar */}
+        <div className="sidebar">
+          <div className="sidebar-header">
+            <div className="spotify-logo">
+              <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15 0C6.72042 0 0 6.72043 0 15C0 23.2975 6.72042 30 15 30C23.2975 30 30 23.2796 30 15C30.0179 6.72043 23.2975 0 15 0ZM21.8817 21.6487C21.6129 22.0968 21.0394 22.2222 20.5914 21.9534C17.0609 19.8029 12.6344 19.319 7.40142 20.5018C6.89963 20.6093 6.39784 20.3047 6.29031 19.8029C6.18279 19.3011 6.48745 18.7993 6.98924 18.6918C12.7061 17.3835 17.6165 17.9391 21.5591 20.3584C22.0251 20.6272 22.1684 21.2007 21.8817 21.6487ZM23.7276 17.5627C23.3871 18.1183 22.6702 18.2796 22.1147 17.957C18.0824 15.466 11.9355 14.7491 7.16845 16.2007C6.54121 16.3799 5.89605 16.0394 5.71684 15.4301C5.53763 14.8029 5.87813 14.1577 6.50537 13.9785C11.9534 12.3298 18.7276 13.1183 23.3691 15.9677C23.8889 16.2903 24.0681 17.0072 23.7276 17.5627ZM23.8889 13.2975C19.0502 10.4301 11.0753 10.1613 6.45161 11.5591C5.71684 11.7921 4.92831 11.362 4.69534 10.6272C4.46236 9.89247 4.89247 9.10394 5.62723 8.87097C10.9319 7.25807 19.7491 7.58065 25.3046 10.8781C25.9677 11.2724 26.1828 12.1326 25.7885 12.7957C25.4122 13.4767 24.5519 13.6918 23.8889 13.2975Z" fill="#1ED760"/>
+              </svg>
+              <span className="spotify-text">Spotify</span>
+            </div>
+
+            <nav className="sidebar-nav">
+              <button className="nav-button active">
+                <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M9.25 13V8.33333C9.25 8.17862 9.18854 8.03025 9.07915 7.92085C8.96975 7.81146 8.82138 7.75 8.66667 7.75H6.33333C6.17862 7.75 6.03025 7.81146 5.92085 7.92085C5.81146 8.03025 5.75 8.17862 5.75 8.33333V13" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M2.25 6.58334C2.24996 6.41363 2.28694 6.24595 2.35838 6.092C2.42981 5.93806 2.53397 5.80155 2.66358 5.692L6.74692 2.192C6.95749 2.01403 7.22429 1.91639 7.5 1.91639C7.77571 1.91639 8.04251 2.01403 8.25308 2.192L12.3364 5.692C12.466 5.80155 12.5702 5.93806 12.6416 6.092C12.7131 6.24595 12.75 6.41363 12.75 6.58334V11.8333C12.75 12.1428 12.6271 12.4395 12.4083 12.6583C12.1895 12.8771 11.8928 13 11.5833 13H3.41667C3.10725 13 2.8105 12.8771 2.59171 12.6583C2.37292 12.4395 2.25 12.1428 2.25 11.8333V6.58334Z" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                Home
+              </button>
+              <button className="nav-button">
+                <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M12.75 12.5L10.2183 9.96834" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M6.91667 11.3333C9.494 11.3333 11.5833 9.244 11.5833 6.66667C11.5833 4.08934 9.494 2 6.91667 2C4.33934 2 2.25 4.08934 2.25 6.66667C2.25 9.244 4.33934 11.3333 6.91667 11.3333Z" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                Search
+              </button>
+            </nav>
+          </div>
+
+          <div className="sidebar-divider"></div>
+
+          <div className="sidebar-library">
+            <div className="library-header">
+              <button className="library-button">
+                <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M9.83333 4.25L12.1667 12.4167" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M7.5 4.25V12.4167" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M5.16667 5.41667V12.4167" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M2.83333 3.08333V12.4167" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                Your Library
+              </button>
+              <button className="add-button">
+                <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M3.16667 7.75H11.3333" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M7.25 3.66667V11.8333" stroke="#D1D5DC" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+            </div>
+
+            <div className="sidebar-playlists">
+              {sidebarPlaylists.map((playlist, index) => (
+                <button
+                  key={index}
+                  className="playlist-item"
+                  onClick={() => index === 0 && this.handlePlayPlaylist(0)}
+                >
+                  <div className={`playlist-icon ${playlist.icon === 'heart' ? 'heart-icon' : ''}`}>
+                    {playlist.icon === 'heart' ? (
+                      <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M1.66667 5.79167C1.66668 5.14254 1.8636 4.50868 2.23141 3.97381C2.59923 3.43894 3.12064 3.02822 3.72677 2.7959C4.33291 2.56358 4.99526 2.5206 5.62634 2.67261C6.25742 2.82463 6.82755 3.1645 7.26142 3.64734C7.29198 3.68001 7.32892 3.70606 7.36996 3.72387C7.411 3.74168 7.45526 3.75087 7.5 3.75087C7.54474 3.75087 7.589 3.74168 7.63004 3.72387C7.67108 3.70606 7.70803 3.68001 7.73858 3.64734C8.17109 3.16136 8.74135 2.81863 9.37345 2.66477C10.0056 2.51091 10.6695 2.55321 11.277 2.78604C11.8845 3.01887 12.4066 3.43118 12.774 3.96811C13.1413 4.50504 13.3364 5.14111 13.3333 5.79167C13.3333 7.1275 12.4583 8.125 11.5833 9L8.37967 12.0993C8.27097 12.2241 8.13696 12.3244 7.98653 12.3934C7.8361 12.4625 7.67269 12.4987 7.50717 12.4998C7.34165 12.5008 7.1778 12.4667 7.0265 12.3995C6.87521 12.3324 6.73993 12.2338 6.62967 12.1103L3.41667 9C2.54167 8.125 1.66667 7.13334 1.66667 5.79167Z" fill="white" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    ) : (
+                      <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M5.75 10.75V3.16667L12.75 2V9.58333" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                        <path d="M4 12.5C4.9665 12.5 5.75 11.7165 5.75 10.75C5.75 9.7835 4.9665 9 4 9C3.0335 9 2.25 9.7835 2.25 10.75C2.25 11.7165 3.0335 12.5 4 12.5Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                        <path d="M11 11.3333C11.9665 11.3333 12.75 10.5498 12.75 9.58331C12.75 8.61681 11.9665 7.83331 11 7.83331C10.0335 7.83331 9.25 8.61681 9.25 9.58331C9.25 10.5498 10.0335 11.3333 11 11.3333Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    )}
+                  </div>
+                  <div className="playlist-info">
+                    <div className="playlist-name">{playlist.name}</div>
+                    <div className="playlist-count">{playlist.count} songs</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Main Content */}
+        <div className="main-content">
+          {/* Top Bar */}
+          <div className="top-bar">
+            <div className="nav-controls">
+              <button className="nav-arrow disabled">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M8.75 10.5L5.25 7L8.75 3.5" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+              <button className="nav-arrow disabled">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M5.25 10.5L8.75 7L5.25 3.5" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+              <h1 className="page-title">Good afternoon</h1>
+            </div>
+            <div className="user-controls">
+              <button className="install-button">
+                <svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M9.1333 1.75H12.6333V5.25" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M6.21667 8.16667L12.6333 1.75" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M10.8833 7.58333V11.0833C10.8833 11.3928 10.7604 11.6895 10.5416 11.9083C10.3228 12.1271 10.0261 12.25 9.71663 12.25H3.29997C2.99055 12.25 2.6938 12.1271 2.47501 11.9083C2.25622 11.6895 2.1333 11.3928 2.1333 11.0833V4.66667C2.1333 4.35725 2.25622 4.0605 2.47501 3.84171C2.6938 3.62292 2.99055 3.5 3.29997 3.5H6.79997" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                Install App
+              </button>
+              <button className="notification-button">
+                <svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6.73962 12.25C6.84202 12.4273 6.9893 12.5746 7.16665 12.677C7.344 12.7794 7.54517 12.8333 7.74996 12.8333C7.95474 12.8333 8.15592 12.7794 8.33327 12.677C8.51061 12.5746 8.65789 12.4273 8.76029 12.25" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M2.6529 8.94017C2.57669 9.02369 2.5264 9.12756 2.50814 9.23914C2.48989 9.35071 2.50445 9.46519 2.55006 9.56865C2.59567 9.6721 2.67036 9.76007 2.76504 9.82186C2.85973 9.88365 2.97033 9.91658 3.0834 9.91667H12.4167C12.5298 9.91671 12.6404 9.8839 12.7352 9.82223C12.8299 9.76056 12.9047 9.67269 12.9504 9.5693C12.9961 9.46591 13.0108 9.35146 12.9927 9.23988C12.9746 9.12829 12.9245 9.02436 12.8484 8.94075C12.0726 8.141 11.2501 7.29108 11.2501 4.66667C11.2501 3.73841 10.8813 2.84817 10.2249 2.19179C9.56856 1.53541 8.67832 1.16667 7.75006 1.16667C6.8218 1.16667 5.93157 1.53541 5.27519 2.19179C4.61881 2.84817 4.25006 3.73841 4.25006 4.66667C4.25006 7.29108 3.42698 8.141 2.6529 8.94017Z" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+              <button className="user-button">
+                <svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M11.8333 12.25V11.0833C11.8333 10.4645 11.5875 9.871 11.1499 9.43342C10.7123 8.99583 10.1188 8.75 9.49996 8.75H5.99996C5.38112 8.75 4.78763 8.99583 4.35004 9.43342C3.91246 9.871 3.66663 10.4645 3.66663 11.0833V12.25" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M7.74996 6.41667C9.03862 6.41667 10.0833 5.372 10.0833 4.08333C10.0833 2.79467 9.03862 1.75 7.74996 1.75C6.46129 1.75 5.41663 2.79467 5.41663 4.08333C5.41663 5.372 6.46129 6.41667 7.74996 6.41667Z" stroke="white" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {/* Page Content */}
+          <div className="page-content">
+            {/* Quick Play Section */}
+            <section className="section quick-play-section">
+              <h2 className="section-title">Good afternoon</h2>
+              <div className="quick-play-grid">
+                {quickPlayPlaylists.map((playlist, index) => (
+                  <button
+                    key={index}
+                    className="quick-play-card"
+                    onClick={() => this.handlePlayPlaylist(index)}
+                  >
+                    <div className="quick-play-image"></div>
+                    <h3 className="quick-play-title">{playlist.name}</h3>
+                    <button className="play-button-green">
+                      <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M3.15833 3.16665C3.15826 2.96137 3.21237 2.75971 3.31517 2.58202C3.41798 2.40434 3.56585 2.25693 3.74385 2.15468C3.92185 2.05242 4.12367 1.99894 4.32895 1.99964C4.53423 2.00034 4.73569 2.05519 4.91299 2.15865L11.9112 6.24081C12.0879 6.34329 12.2345 6.49033 12.3365 6.66723C12.4384 6.84413 12.4922 7.0447 12.4924 7.24889C12.4926 7.45308 12.4391 7.65375 12.3375 7.83082C12.2358 8.0079 12.0894 8.15519 11.913 8.25798L4.91299 12.3413C4.73569 12.4448 4.53423 12.4996 4.32895 12.5003C4.12367 12.501 3.92185 12.4475 3.74385 12.3453C3.56585 12.243 3.41798 12.0956 3.31517 11.9179C3.21237 11.7403 3.15826 11.5386 3.15833 11.3333V3.16665Z" stroke="black" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    </button>
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            {/* Made for You Section */}
+            <section className="section playlists-section">
+              <div className="section-header">
+                <h2 className="section-title">Made for You</h2>
+                <button className="show-all-button">Show all</button>
+              </div>
+              <div className="playlists-grid">
+                {playlists.map((playlist, index) => (
+                  <div key={playlist.id} className="playlist-card">
+                    <div className="playlist-card-image-wrapper">
+                      <div className="playlist-card-image"></div>
+                      <button
+                        className="play-button-overlay"
+                        onClick={() => this.handlePlayPlaylist(index)}
+                      >
+                        <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M3.15833 3.16665C3.15826 2.96137 3.21237 2.75971 3.31517 2.58202C3.41798 2.40434 3.56585 2.25693 3.74385 2.15468C3.92185 2.05242 4.12367 1.99894 4.32895 1.99964C4.53423 2.00034 4.73569 2.05519 4.91299 2.15865L11.9112 6.24081C12.0879 6.34329 12.2345 6.49033 12.3365 6.66723C12.4384 6.84413 12.4922 7.0447 12.4924 7.24889C12.4926 7.45308 12.4391 7.65375 12.3375 7.83082C12.2358 8.0079 12.0894 8.15519 11.913 8.25798L4.91299 12.3413C4.73569 12.4448 4.53423 12.4996 4.32895 12.5003C4.12367 12.501 3.92185 12.4475 3.74385 12.3453C3.56585 12.243 3.41798 12.0956 3.31517 11.9179C3.21237 11.7403 3.15826 11.5386 3.15833 11.3333V3.16665Z" stroke="black" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                      </button>
+                    </div>
+                    <div className="playlist-card-info">
+                      <h3 className="playlist-card-title">{playlist.name}</h3>
+                      <p className="playlist-card-description">{playlist.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Recently Played Section */}
+            <section className="section playlists-section">
+              <div className="section-header">
+                <h2 className="section-title">Recently played</h2>
+                <button className="show-all-button">Show all</button>
+              </div>
+              <div className="playlists-grid">
+                {playlists.slice(0, 4).map((playlist, index) => (
+                  <div key={playlist.id} className="playlist-card">
+                    <div className="playlist-card-image-wrapper">
+                      <div className="playlist-card-image"></div>
+                      <button
+                        className="play-button-overlay"
+                        onClick={() => this.handlePlayPlaylist(index)}
+                      >
+                        <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M3.15833 3.16665C3.15826 2.96137 3.21237 2.75971 3.31517 2.58202C3.41798 2.40434 3.56585 2.25693 3.74385 2.15468C3.92185 2.05242 4.12367 1.99894 4.32895 1.99964C4.53423 2.00034 4.73569 2.05519 4.91299 2.15865L11.9112 6.24081C12.0879 6.34329 12.2345 6.49033 12.3365 6.66723C12.4384 6.84413 12.4922 7.0447 12.4924 7.24889C12.4926 7.45308 12.4391 7.65375 12.3375 7.83082C12.2358 8.0079 12.0894 8.15519 11.913 8.25798L4.91299 12.3413C4.73569 12.4448 4.53423 12.4996 4.32895 12.5003C4.12367 12.501 3.92185 12.4475 3.74385 12.3453C3.56585 12.243 3.41798 12.0956 3.31517 11.9179C3.21237 11.7403 3.15826 11.5386 3.15833 11.3333V3.16665Z" stroke="black" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                      </button>
+                    </div>
+                    <div className="playlist-card-info">
+                      <h3 className="playlist-card-title">{playlist.name}</h3>
+                      <p className="playlist-card-description">{playlist.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          {/* Music Player */}
+          <div className="music-player-wrapper">
+            <div className="music-player">
+              <div className="player-track-info">
+                <div className="track-image"></div>
+                <div className="track-details">
+                  <h4 className="track-name">{currentTrack.name}</h4>
+                  <p className="track-artist">{currentTrack.artist}</p>
+                </div>
+                <button className="like-button active">
+                  <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M1.91666 6.29173C1.91667 5.6426 2.11359 5.00874 2.4814 4.47387C2.84922 3.939 3.37062 3.52828 3.97676 3.29596C4.5829 3.06365 5.24525 3.02066 5.87633 3.17267C6.50741 3.32469 7.07754 3.66456 7.51141 4.1474C7.54197 4.18007 7.57891 4.20612 7.61995 4.22393C7.66099 4.24174 7.70525 4.25093 7.74999 4.25093C7.79473 4.25093 7.83899 4.24174 7.88003 4.22393C7.92107 4.20612 7.95801 4.18007 7.98857 4.1474C8.42108 3.66142 8.99134 3.3187 9.62344 3.16483C10.2555 3.01097 10.9195 3.05327 11.527 3.2861C12.1345 3.51893 12.6566 3.93124 13.024 4.46817C13.3913 5.0051 13.5864 5.64117 13.5833 6.29173C13.5833 7.62756 12.7083 8.62506 11.8333 9.50006L8.62966 12.5993C8.52096 12.7242 8.38695 12.8244 8.23652 12.8935C8.08609 12.9626 7.92268 12.9988 7.75716 12.9999C7.59164 13.0009 7.42778 12.9667 7.27649 12.8996C7.1252 12.8324 6.98992 12.7338 6.87966 12.6104L3.66666 9.50006C2.79166 8.62506 1.91666 7.6334 1.91666 6.29173Z" fill="#00C950" stroke="#00C950" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+                <button className="pip-button">
+                  <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12.5 6.00004V4.25004C12.5 3.94062 12.3771 3.64388 12.1583 3.42508C11.9395 3.20629 11.6427 3.08337 11.3333 3.08337H2.58332C2.2739 3.08337 1.97716 3.20629 1.75837 3.42508C1.53957 3.64388 1.41666 3.94062 1.41666 4.25004V10.0834C1.41666 10.725 1.94166 11.25 2.58332 11.25H4.91666" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M11.9167 8.33337H8.41667C7.77233 8.33337 7.25 8.85571 7.25 9.50004V11.25C7.25 11.8944 7.77233 12.4167 8.41667 12.4167H11.9167C12.561 12.4167 13.0833 11.8944 13.0833 11.25V9.50004C13.0833 8.85571 12.561 8.33337 11.9167 8.33337Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+
+              <div className="player-controls">
+                <div className="control-buttons">
+                  <button className="control-button shuffle">
+                    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M11.125 8.41663L13.4583 10.75L11.125 13.0833" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M11.125 1.41663L13.4583 3.74996L11.125 6.08329" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1.79169 10.7499H2.9426C3.31972 10.7525 3.69185 10.6636 4.02711 10.4909C4.36236 10.3182 4.65076 10.0668 4.8676 9.75827L8.0491 4.7416C8.26594 4.43304 8.55434 4.18165 8.8896 4.00894C9.22486 3.83623 9.59698 3.74736 9.9741 3.74993H13.4584" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1.79169 3.74993H2.94202C3.37687 3.74691 3.80392 3.86546 4.17498 4.09222C4.54603 4.31898 4.84634 4.64492 5.04202 5.03327" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M13.4583 10.75H9.9344C9.55207 10.7461 9.17655 10.6483 8.84088 10.4652C8.50521 10.2821 8.21968 10.0193 8.0094 9.7L7.79999 9.4375" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                  <button className="control-button prev" onClick={this.handleClickPrevious}>
+                    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M10.6081 2.74964C10.7852 2.64341 10.9872 2.58607 11.1937 2.58347C11.4001 2.58086 11.6035 2.63309 11.7832 2.73481C11.9628 2.83653 12.1123 2.98411 12.2163 3.16247C12.3203 3.34083 12.375 3.54359 12.375 3.75005V10.7501C12.375 10.9565 12.3203 11.1593 12.2163 11.3376C12.1123 11.516 11.9628 11.6636 11.7832 11.7653C11.6035 11.867 11.4001 11.9192 11.1937 11.9166C10.9872 11.914 10.7852 11.8567 10.6081 11.7505L4.77654 8.25163C4.60342 8.1482 4.46007 8.00166 4.36047 7.82631C4.26087 7.65096 4.20843 7.45279 4.20825 7.25113C4.20808 7.04947 4.26018 6.85121 4.35947 6.67568C4.45876 6.50016 4.60185 6.35337 4.77479 6.24964L10.6081 2.74964Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1.875 11.9167V2.58337" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                  <button className="control-button play-pause">
+                    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M3.15833 3.16665C3.15826 2.96137 3.21237 2.75971 3.31517 2.58202C3.41798 2.40434 3.56585 2.25693 3.74385 2.15468C3.92185 2.05242 4.12367 1.99894 4.32895 1.99964C4.53423 2.00034 4.73569 2.05519 4.91299 2.15865L11.9112 6.24081C12.0879 6.34329 12.2345 6.49033 12.3365 6.66723C12.4384 6.84413 12.4922 7.0447 12.4924 7.24889C12.4926 7.45308 12.4391 7.65375 12.3375 7.83082C12.2358 8.0079 12.0894 8.15519 11.913 8.25798L4.91299 12.3413C4.73569 12.4448 4.53423 12.4996 4.32895 12.5003C4.12367 12.501 3.92185 12.4475 3.74385 12.3453C3.56585 12.243 3.41798 12.0956 3.31517 11.9179C3.21237 11.7403 3.15826 11.5386 3.15833 11.3333V3.16665Z" stroke="black" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                  <button className="control-button next" onClick={this.handleClickNext}>
+                    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M12.875 2.58337V11.9167" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M4.14192 2.74964C3.96488 2.64341 3.76283 2.58607 3.55639 2.58347C3.34994 2.58086 3.14651 2.63309 2.96685 2.73481C2.78719 2.83653 2.63774 2.98411 2.53376 3.16247C2.42978 3.34083 2.375 3.54359 2.375 3.75005V10.7501C2.375 10.9565 2.42978 11.1593 2.53376 11.3376C2.63774 11.516 2.78719 11.6636 2.96685 11.7653C3.14651 11.867 3.34994 11.9192 3.55639 11.9166C3.76283 11.914 3.96488 11.8567 4.14192 11.7505L9.9735 8.25163C10.1466 8.1482 10.29 8.00166 10.3896 7.82631C10.4892 7.65096 10.5416 7.45279 10.5418 7.25113C10.542 7.04947 10.4899 6.85121 10.3906 6.67568C10.2913 6.50016 10.1482 6.35337 9.97525 6.24964L4.14192 2.74964Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                  <button className="control-button repeat">
+                    <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M10.0417 1.41663L12.375 3.74996L10.0417 6.08329" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M1.875 6.66667V6.08333C1.875 5.46449 2.12083 4.871 2.55842 4.43342C2.996 3.99583 3.58949 3.75 4.20833 3.75H12.375" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M4.20833 13.0833L1.875 10.75L4.20833 8.41663" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                      <path d="M12.375 7.83337V8.41671C12.375 9.03555 12.1292 9.62904 11.6916 10.0666C11.254 10.5042 10.6605 10.75 10.0417 10.75H1.875" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  </button>
+                </div>
+                <div className="progress-bar-container">
+                  <span className="time-display">0:00</span>
+                  <div className="progress-bar">
+                    <div className="progress-filled"></div>
+                    <div className="progress-handle"></div>
+                  </div>
+                  <span className="time-display">3:20</span>
+                </div>
+              </div>
+
+              <div className="player-volume">
+                <button className="volume-button">
+                  <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M6.41663 3.49281C6.41651 3.41156 6.39233 3.33216 6.34713 3.26464C6.30193 3.19712 6.23775 3.1445 6.16267 3.11342C6.0876 3.08235 6.005 3.0742 5.92531 3.09002C5.84561 3.10584 5.77239 3.14491 5.71488 3.20231L3.74088 5.17573C3.66469 5.25236 3.57406 5.31312 3.47423 5.35447C3.3744 5.39583 3.26735 5.41696 3.15929 5.41664H1.74996C1.59525 5.41664 1.44688 5.4781 1.33748 5.5875C1.22808 5.69689 1.16663 5.84527 1.16663 5.99998V9.49998C1.16663 9.65468 1.22808 9.80306 1.33748 9.91245C1.44688 10.0219 1.59525 10.0833 1.74996 10.0833H3.15929C3.26735 10.083 3.3744 10.1041 3.47423 10.1455C3.57406 10.1868 3.66469 10.2476 3.74088 10.3242L5.71429 12.2982C5.77181 12.3559 5.84514 12.3951 5.92499 12.411C6.00484 12.4269 6.08762 12.4188 6.16283 12.3876C6.23805 12.3565 6.30232 12.3037 6.3475 12.2359C6.39268 12.1682 6.41674 12.0886 6.41663 12.0071V3.49281Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M9.33337 6C9.71202 6.50486 9.91671 7.11892 9.91671 7.75C9.91671 8.38108 9.71202 8.99514 9.33337 9.5" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M11.2957 11.4623C11.7832 10.9748 12.1699 10.396 12.4337 9.75903C12.6976 9.12207 12.8334 8.43938 12.8334 7.74993C12.8334 7.06049 12.6976 6.37779 12.4337 5.74083C12.1699 5.10386 11.7832 4.52511 11.2957 4.0376" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+                <div className="volume-bar-wrapper">
+                  <div className="volume-bar">
+                    <div className="volume-filled"></div>
+                    <div className="volume-handle"></div>
+                  </div>
+                </div>
+                <button className="queue-button">
+                  <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9.33333 3.66663H1.75" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M6.41667 7.75H1.75" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M6.41667 11.8334H1.75" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M12.25 10.0833V3.66663" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M10.5 11.8334C11.4665 11.8334 12.25 11.0499 12.25 10.0834C12.25 9.11688 11.4665 8.33337 10.5 8.33337C9.5335 8.33337 8.75 9.11688 8.75 10.0834C8.75 11.0499 9.5335 11.8334 10.5 11.8334Z" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+                <button className="fullscreen-button">
+                  <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9.25 2.5H12.75V6" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M12.75 2.5L8.66663 6.58333" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M2.25 13L6.33333 8.91663" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                    <path d="M5.75 13H2.25V9.5" stroke="#99A1AF" strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Hidden Audio Player (using library for functionality) */}
+        <div style={{ display: 'none' }}>
+          <AudioPlayer
+            ref={this.audioRef}
+            src={currentTrack.src}
+            autoPlay={false}
+            autoPlayAfterSrcChange={false}
+            showSkipControls={true}
+            onClickPrevious={this.handleClickPrevious}
+            onClickNext={this.handleClickNext}
+            onEnded={this.handleClickNext}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+export default SpotifyClone

--- a/stories/spotify-clone.tsx
+++ b/stories/spotify-clone.tsx
@@ -56,46 +56,52 @@ const playlists: Playlist[] = [
     name: "Today's Top Hits",
     description: 'The most played songs on Spotify right now',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtdXNpYyUyMGFydGlzdCUyMGJhbmQlMjBwZXJmb3JtYW5jZXxlbnwxfHx8fDE3NTk1MTQ1MjV8MA&ixlib=rb-4.1.0&q=80&w=400',
   },
   {
     id: 'rapcaviar',
     name: 'RapCaviar',
     description: 'New music and big tracks from hip hop',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1631061434620-db65394197e2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25jZXJ0JTIwbGl2ZSUyMG11c2ljJTIwc3RhZ2V8ZW58MXx8fHwxNzU5NTE0NTI5fDA&ixlib=rb-4.1.0&q=80&w=400',
   },
   {
     id: 'chill-hits',
     name: 'Chill Hits',
     description: 'Chill tracks for the perfect vibe',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1652626627248-2f659cdbd6cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwbGF5bGlzdCUyMGNvdmVyJTIwbXVzaWMlMjBtb29kfGVufDF8fHx8MTc1OTUxNDUzMnww&ixlib=rb-4.1.0&q=80&w=400',
   },
   {
     id: 'pop-rising',
     name: 'Pop Rising',
     description: 'The biggest songs in pop are right here',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1629923759854-156b88c433aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxhbGJ1bSUyMGNvdmVyJTIwbXVzaWMlMjB2aW55bHxlbnwxfHx8fDE3NTk1MDk1NTZ8MA&ixlib=rb-4.1.0&q=80&w=400',
   },
   {
     id: 'rock-classics',
     name: 'Rock Classics',
     description: 'Rock legends & epic guitar solos',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtdXNpYyUyMGFydGlzdCUyMGJhbmQlMjBwZXJmb3JtYW5jZXxlbnwxfHx8fDE3NTk1MTQ1MjV8MA&ixlib=rb-4.1.0&q=80&w=400',
   },
   {
     id: 'indie-mix',
     name: 'Indie Mix',
     description: 'The best indie tracks, updated weekly',
     tracks: sampleTracks,
+    image: 'https://images.unsplash.com/photo-1631061434620-db65394197e2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25jZXJ0JTIwbGl2ZSUyMG11c2ljJTIwc3RhZ2V8ZW58MXx8fHwxNzU5NTE0NTI5fDA&ixlib=rb-4.1.0&q=80&w=400',
   },
 ]
 
 const quickPlayPlaylists = [
-  { name: "Today's Top Hits" },
-  { name: 'RapCaviar' },
-  { name: 'Chill Hits' },
-  { name: 'Pop Rising' },
-  { name: 'Rock Classics' },
-  { name: 'Indie Mix' },
+  { name: "Today's Top Hits", image: 'https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtdXNpYyUyMGFydGlzdCUyMGJhbmQlMjBwZXJmb3JtYW5jZXxlbnwxfHx8fDE3NTk1MTQ1MjV8MA&ixlib=rb-4.1.0&q=80&w=400' },
+  { name: 'RapCaviar', image: 'https://images.unsplash.com/photo-1631061434620-db65394197e2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25jZXJ0JTIwbGl2ZSUyMG11c2ljJTIwc3RhZ2V8ZW58MXx8fHwxNzU5NTE0NTI5fDA&ixlib=rb-4.1.0&q=80&w=400' },
+  { name: 'Chill Hits', image: 'https://images.unsplash.com/photo-1652626627248-2f659cdbd6cc?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwbGF5bGlzdCUyMGNvdmVyJTIwbXVzaWMlMjBtb29kfGVufDF8fHx8MTc1OTUxNDUzMnww&ixlib=rb-4.1.0&q=80&w=400' },
+  { name: 'Pop Rising', image: 'https://images.unsplash.com/photo-1629923759854-156b88c433aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxhbGJ1bSUyMGNvdmVyJTIwbXVzaWMlMjB2aW55bHxlbnwxfHx8fDE3NTk1MDk1NTZ8MA&ixlib=rb-4.1.0&q=80&w=400' },
+  { name: 'Rock Classics', image: 'https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtdXNpYyUyMGFydGlzdCUyMGJhbmQlMjBwZXJmb3JtYW5jZXxlbnwxfHx8fDE3NTk1MTQ1MjV8MA&ixlib=rb-4.1.0&q=80&w=400' },
+  { name: 'Indie Mix', image: 'https://images.unsplash.com/photo-1631061434620-db65394197e2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjb25jZXJ0JTIwbGl2ZSUyMG11c2ljJTIwc3RhZ2V8ZW58MXx8fHwxNzU5NTE0NTI5fDA&ixlib=rb-4.1.0&q=80&w=400' },
 ]
 
 const sidebarPlaylists = [
@@ -282,7 +288,7 @@ class SpotifyClone extends Component<{}, SpotifyCloneState> {
                     className="quick-play-card"
                     onClick={() => this.handlePlayPlaylist(index)}
                   >
-                    <div className="quick-play-image"></div>
+                    <div className="quick-play-image" style={{ backgroundImage: `url(${playlist.image})` }}></div>
                     <h3 className="quick-play-title">{playlist.name}</h3>
                     <button className="play-button-green">
                       <svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -304,7 +310,7 @@ class SpotifyClone extends Component<{}, SpotifyCloneState> {
                 {playlists.map((playlist, index) => (
                   <div key={playlist.id} className="playlist-card">
                     <div className="playlist-card-image-wrapper">
-                      <div className="playlist-card-image"></div>
+                      <div className="playlist-card-image" style={{ backgroundImage: `url(${playlist.image})` }}></div>
                       <button
                         className="play-button-overlay"
                         onClick={() => this.handlePlayPlaylist(index)}
@@ -333,7 +339,7 @@ class SpotifyClone extends Component<{}, SpotifyCloneState> {
                 {playlists.slice(0, 4).map((playlist, index) => (
                   <div key={playlist.id} className="playlist-card">
                     <div className="playlist-card-image-wrapper">
-                      <div className="playlist-card-image"></div>
+                      <div className="playlist-card-image" style={{ backgroundImage: `url(${playlist.image})` }}></div>
                       <button
                         className="play-button-overlay"
                         onClick={() => this.handlePlayPlaylist(index)}
@@ -357,7 +363,7 @@ class SpotifyClone extends Component<{}, SpotifyCloneState> {
           <div className="music-player-wrapper">
             <div className="music-player">
               <div className="player-track-info">
-                <div className="track-image"></div>
+                <div className="track-image" style={{ backgroundImage: `url(${currentPlaylist.image})` }}></div>
                 <div className="track-details">
                   <h4 className="track-name">{currentTrack.name}</h4>
                   <p className="track-artist">{currentTrack.artist}</p>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    open: true,
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
-    open: true,
   },
   css: {
     preprocessorOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.4.tgz#12a550b8794452df4c8b084f95003bce1742d496"
+  integrity sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.28.3"
+    "@babel/helper-compilation-targets" "^7.27.2"
+    "@babel/helper-module-transforms" "^7.28.3"
+    "@babel/helpers" "^7.28.4"
+    "@babel/parser" "^7.28.4"
+    "@babel/template" "^7.27.2"
+    "@babel/traverse" "^7.28.4"
+    "@babel/types" "^7.28.4"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.28.3", "@babel/generator@^7.7.2":
   version "7.28.3"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.3.tgz#9626c1741c650cbac39121694a0f2d7451b8ef3e"
@@ -228,12 +249,27 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.28.2"
 
+"@babel/helpers@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.4.tgz#fe07274742e95bdf7cf1443593eeb8926ab63827"
+  integrity sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==
+  dependencies:
+    "@babel/template" "^7.27.2"
+    "@babel/types" "^7.28.4"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.27.2", "@babel/parser@^7.28.3":
   version "7.28.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.3.tgz#d2d25b814621bca5fe9d172bc93792547e7a2a71"
   integrity sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==
   dependencies:
     "@babel/types" "^7.28.2"
+
+"@babel/parser@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
+  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
+  dependencies:
+    "@babel/types" "^7.28.4"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
   version "7.27.1"
@@ -735,6 +771,20 @@
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.27.1"
 
+"@babel/plugin-transform-react-jsx-self@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz#af678d8506acf52c577cac73ff7fe6615c85fc92"
+  integrity sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
+"@babel/plugin-transform-react-jsx-source@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz#dcfe2c24094bb757bf73960374e7c55e434f19f0"
+  integrity sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+
 "@babel/plugin-transform-react-jsx@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz#1023bc94b78b0a2d68c82b5e96aed573bcfb9db0"
@@ -1001,10 +1051,31 @@
     "@babel/types" "^7.28.2"
     debug "^4.3.1"
 
+"@babel/traverse@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.28.4.tgz#8d456101b96ab175d487249f60680221692b958b"
+  integrity sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@babel/generator" "^7.28.3"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.28.4"
+    "@babel/template" "^7.27.2"
+    "@babel/types" "^7.28.4"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.28.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.2.tgz#da9db0856a9a88e0a13b019881d7513588cf712b"
   integrity sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+
+"@babel/types@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
+  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
@@ -1024,130 +1095,260 @@
   resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
 
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
+
 "@esbuild/aix-ppc64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz#bef96351f16520055c947aba28802eede3c9e9a9"
   integrity sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==
+
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
 
 "@esbuild/android-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz#d2e70be7d51a529425422091e0dcb90374c1546c"
   integrity sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==
 
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
+
 "@esbuild/android-arm@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.9.tgz#d2a753fe2a4c73b79437d0ba1480e2d760097419"
   integrity sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==
+
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
 
 "@esbuild/android-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.9.tgz#5278836e3c7ae75761626962f902a0d55352e683"
   integrity sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==
 
+"@esbuild/darwin-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz#6af6bb1d05887dac515de1b162b59dc71212ed76"
+  integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
+
 "@esbuild/darwin-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz#f1513eaf9ec8fa15dcaf4c341b0f005d3e8b47ae"
   integrity sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==
+
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
 
 "@esbuild/darwin-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz#e27dbc3b507b3a1cea3b9280a04b8b6b725f82be"
   integrity sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==
 
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
+
 "@esbuild/freebsd-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz#364e3e5b7a1fd45d92be08c6cc5d890ca75908ca"
   integrity sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==
+
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
 
 "@esbuild/freebsd-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz#7c869b45faeb3df668e19ace07335a0711ec56ab"
   integrity sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==
 
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
+
 "@esbuild/linux-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz#48d42861758c940b61abea43ba9a29b186d6cb8b"
   integrity sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==
+
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
 
 "@esbuild/linux-arm@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz#6ce4b9cabf148274101701d112b89dc67cc52f37"
   integrity sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==
 
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
+
 "@esbuild/linux-ia32@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz#207e54899b79cac9c26c323fc1caa32e3143f1c4"
   integrity sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==
+
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
 
 "@esbuild/linux-loong64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz#0ba48a127159a8f6abb5827f21198b999ffd1fc0"
   integrity sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==
 
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
+
 "@esbuild/linux-mips64el@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz#a4d4cc693d185f66a6afde94f772b38ce5d64eb5"
   integrity sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==
+
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
 
 "@esbuild/linux-ppc64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz#0f5805c1c6d6435a1dafdc043cb07a19050357db"
   integrity sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==
 
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
+
 "@esbuild/linux-riscv64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz#6776edece0f8fca79f3386398b5183ff2a827547"
   integrity sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==
+
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
 
 "@esbuild/linux-s390x@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz#3f6f29ef036938447c2218d309dc875225861830"
   integrity sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==
 
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
+
 "@esbuild/linux-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz#831fe0b0e1a80a8b8391224ea2377d5520e1527f"
   integrity sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==
+
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
 
 "@esbuild/netbsd-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz#06f99d7eebe035fbbe43de01c9d7e98d2a0aa548"
   integrity sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==
 
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
+
 "@esbuild/netbsd-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz#db99858e6bed6e73911f92a88e4edd3a8c429a52"
   integrity sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==
+
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
 
 "@esbuild/openbsd-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz#afb886c867e36f9d86bb21e878e1185f5d5a0935"
   integrity sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==
 
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
+
 "@esbuild/openbsd-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz#30855c9f8381fac6a0ef5b5f31ac6e7108a66ecf"
   integrity sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==
+
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
 
 "@esbuild/openharmony-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz#2f2144af31e67adc2a8e3705c20c2bd97bd88314"
   integrity sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==
 
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
+
 "@esbuild/sunos-x64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz#69b99a9b5bd226c9eb9c6a73f990fddd497d732e"
   integrity sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==
+
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
 
 "@esbuild/win32-arm64@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz#d789330a712af916c88325f4ffe465f885719c6b"
   integrity sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==
 
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
+
 "@esbuild/win32-ia32@0.25.9":
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz#52fc735406bd49688253e74e4e837ac2ba0789e3"
   integrity sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==
+
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
 "@esbuild/win32-x64@0.25.9":
   version "0.25.9"
@@ -1433,6 +1634,14 @@
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
@@ -1619,6 +1828,121 @@
     "@parcel/watcher-win32-ia32" "2.5.1"
     "@parcel/watcher-win32-x64" "2.5.1"
 
+"@rolldown/pluginutils@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz#95253608c4629eb2a5f3d656009ac9ba031eb292"
+  integrity sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==
+
+"@rollup/rollup-android-arm-eabi@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz#59e7478d310f7e6a7c72453978f562483828112f"
+  integrity sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==
+
+"@rollup/rollup-android-arm64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz#a825192a0b1b2f27a5c950c439e7e37a33c5d056"
+  integrity sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==
+
+"@rollup/rollup-darwin-arm64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz#4ee37078bccd725ae3c5f30ef92efc8e1bf886f3"
+  integrity sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==
+
+"@rollup/rollup-darwin-x64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz#43cc08bd05bf9f388f125e7210a544e62d368d90"
+  integrity sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==
+
+"@rollup/rollup-freebsd-arm64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz#bc8e640e28abe52450baf3fc80d9b26d9bb6587d"
+  integrity sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==
+
+"@rollup/rollup-freebsd-x64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz#e981a22e057cc8c65bb523019d344d3a66b15bbc"
+  integrity sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz#4036b68904f392a20f3499d63b33e055b67eb274"
+  integrity sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==
+
+"@rollup/rollup-linux-arm-musleabihf@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz#d3b1b9589606e0ff916801c855b1ace9e733427a"
+  integrity sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==
+
+"@rollup/rollup-linux-arm64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz#cbf0943c477e3b96340136dd3448eaf144378cf2"
+  integrity sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==
+
+"@rollup/rollup-linux-arm64-musl@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz#837f5a428020d5dce1c3b4cc049876075402cf78"
+  integrity sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==
+
+"@rollup/rollup-linux-loong64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz#532c214ababb32ab4bc21b4054278b9a8979e516"
+  integrity sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==
+
+"@rollup/rollup-linux-ppc64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz#93900163b61b49cee666d10ee38257a8b1dd161a"
+  integrity sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==
+
+"@rollup/rollup-linux-riscv64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz#f0ffdcc7066ca04bc972370c74289f35c7a7dc42"
+  integrity sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==
+
+"@rollup/rollup-linux-riscv64-musl@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz#361695c39dbe96773509745d77a870a32a9f8e48"
+  integrity sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==
+
+"@rollup/rollup-linux-s390x-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz#09fc6cc2e266a2324e366486ae5d1bca48c43a6a"
+  integrity sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==
+
+"@rollup/rollup-linux-x64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz#aa9d5b307c08f05d3454225bb0a2b4cc87eeb2e1"
+  integrity sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==
+
+"@rollup/rollup-linux-x64-musl@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz#26949e5b4645502a61daba2f7a8416bd17cb5382"
+  integrity sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==
+
+"@rollup/rollup-openharmony-arm64@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz#ef493c072f9dac7e0edb6c72d63366846b6ffcd9"
+  integrity sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==
+
+"@rollup/rollup-win32-arm64-msvc@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz#56e1aaa6a630d2202ee7ec0adddd05cf384ffd44"
+  integrity sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz#0a44bbf933a9651c7da2b8569fa448dec0de7480"
+  integrity sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==
+
+"@rollup/rollup-win32-x64-gnu@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz#730e12f0b60b234a7c02d5d3179ca3ec7972033d"
+  integrity sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==
+
+"@rollup/rollup-win32-x64-msvc@4.52.4":
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz#5b2dd648a960b8fa00d76f2cc4eea2f03daa80f4"
+  integrity sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1803,7 +2127,7 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
-"@types/babel__core@^7.1.14", "@types/babel__core@^7.18.0":
+"@types/babel__core@^7.1.14", "@types/babel__core@^7.18.0", "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -1883,7 +2207,7 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.8":
+"@types/estree@*", "@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -2113,6 +2437,18 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@vitejs/plugin-react@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-5.0.4.tgz#d642058e89c5b712655c8cbd13482f5813519602"
+  integrity sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==
+  dependencies:
+    "@babel/core" "^7.28.4"
+    "@babel/plugin-transform-react-jsx-self" "^7.27.1"
+    "@babel/plugin-transform-react-jsx-source" "^7.27.1"
+    "@rolldown/pluginutils" "1.0.0-beta.38"
+    "@types/babel__core" "^7.20.5"
+    react-refresh "^0.17.0"
 
 "@vitest/expect@3.2.4":
   version "3.2.4"
@@ -3745,6 +4081,38 @@ esbuild-register@^3.5.0:
     "@esbuild/win32-ia32" "0.25.9"
     "@esbuild/win32-x64" "0.25.9"
 
+esbuild@^0.25.0:
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.10.tgz#37f5aa5cd14500f141be121c01b096ca83ac34a9"
+  integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.10"
+    "@esbuild/android-arm" "0.25.10"
+    "@esbuild/android-arm64" "0.25.10"
+    "@esbuild/android-x64" "0.25.10"
+    "@esbuild/darwin-arm64" "0.25.10"
+    "@esbuild/darwin-x64" "0.25.10"
+    "@esbuild/freebsd-arm64" "0.25.10"
+    "@esbuild/freebsd-x64" "0.25.10"
+    "@esbuild/linux-arm" "0.25.10"
+    "@esbuild/linux-arm64" "0.25.10"
+    "@esbuild/linux-ia32" "0.25.10"
+    "@esbuild/linux-loong64" "0.25.10"
+    "@esbuild/linux-mips64el" "0.25.10"
+    "@esbuild/linux-ppc64" "0.25.10"
+    "@esbuild/linux-riscv64" "0.25.10"
+    "@esbuild/linux-s390x" "0.25.10"
+    "@esbuild/linux-x64" "0.25.10"
+    "@esbuild/netbsd-arm64" "0.25.10"
+    "@esbuild/netbsd-x64" "0.25.10"
+    "@esbuild/openbsd-arm64" "0.25.10"
+    "@esbuild/openbsd-x64" "0.25.10"
+    "@esbuild/openharmony-arm64" "0.25.10"
+    "@esbuild/sunos-x64" "0.25.10"
+    "@esbuild/win32-arm64" "0.25.10"
+    "@esbuild/win32-ia32" "0.25.10"
+    "@esbuild/win32-x64" "0.25.10"
+
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -4121,6 +4489,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -4269,7 +4642,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -6884,6 +7257,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pidtree@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
@@ -6969,7 +7347,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.33:
+postcss@^8.4.33, postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
@@ -7124,6 +7502,11 @@ react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-refresh@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
+  integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
 
 "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^19:
   version "19.1.1"
@@ -7433,6 +7816,37 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup@^4.43.0:
+  version "4.52.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.52.4.tgz#71e64cce96a865fcbaa6bb62c6e82807f4e378a1"
+  integrity sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.52.4"
+    "@rollup/rollup-android-arm64" "4.52.4"
+    "@rollup/rollup-darwin-arm64" "4.52.4"
+    "@rollup/rollup-darwin-x64" "4.52.4"
+    "@rollup/rollup-freebsd-arm64" "4.52.4"
+    "@rollup/rollup-freebsd-x64" "4.52.4"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.52.4"
+    "@rollup/rollup-linux-arm-musleabihf" "4.52.4"
+    "@rollup/rollup-linux-arm64-gnu" "4.52.4"
+    "@rollup/rollup-linux-arm64-musl" "4.52.4"
+    "@rollup/rollup-linux-loong64-gnu" "4.52.4"
+    "@rollup/rollup-linux-ppc64-gnu" "4.52.4"
+    "@rollup/rollup-linux-riscv64-gnu" "4.52.4"
+    "@rollup/rollup-linux-riscv64-musl" "4.52.4"
+    "@rollup/rollup-linux-s390x-gnu" "4.52.4"
+    "@rollup/rollup-linux-x64-gnu" "4.52.4"
+    "@rollup/rollup-linux-x64-musl" "4.52.4"
+    "@rollup/rollup-openharmony-arm64" "4.52.4"
+    "@rollup/rollup-win32-arm64-msvc" "4.52.4"
+    "@rollup/rollup-win32-ia32-msvc" "4.52.4"
+    "@rollup/rollup-win32-x64-gnu" "4.52.4"
+    "@rollup/rollup-win32-x64-msvc" "4.52.4"
+    fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -8102,6 +8516,14 @@ tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
+tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+
 tinyrainbow@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
@@ -8431,6 +8853,20 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+vite@^7.1.9:
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.9.tgz#ba844410e5d0c0f2a4eaf17a52af60ebea322cbf"
+  integrity sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 w3c-xmlserializer@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Purpose

Based on the conversation, the user wanted to:
1. Connect missing images to their current design from JSON data
2. Wire up the react-player with the frontend so that the music player actually plays music, building on the working Storybook test that could play music

## Code changes

This PR adds a standalone Spotify Clone application alongside the existing Storybook setup:

- **New Vite app structure**: Added `app/` directory with `main.tsx` entry point and global styles
- **HTML entry point**: Created `index.html` for the Vite application
- **Development setup**: Added Vite configuration and new npm scripts (`dev`, `preview`, `start`)
- **Documentation**: Created `DEV_SETUP.md` with instructions for running both the Spotify app and Storybook
- **Dependencies**: Added Vite, React plugin, and related build tools to package.json
- **Gitignore updates**: Added `dist/` and `*.local` to ignore build artifacts
- **Styling**: Added comprehensive SCSS styles for the Spotify Clone component with sidebar, main content, and player interface

The app now runs on `http://localhost:3000` via `npm run dev` while Storybook continues to run on port 9000, allowing both development environments to coexist.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/47e82d8e4ab94cdd97b6adfee1a4bac2/zen-haven)

👀 [Preview Link](https://47e82d8e4ab94cdd97b6adfee1a4bac2-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>47e82d8e4ab94cdd97b6adfee1a4bac2</projectId>-->
<!--<branchName>zen-haven</branchName>-->